### PR TITLE
BE: Issue Logs - Split logs on \n before saving to DB

### DIFF
--- a/backend/pkg/controllers/main.controller.go
+++ b/backend/pkg/controllers/main.controller.go
@@ -105,17 +105,19 @@ func (c *MainController) LogAnalysisTask(ctx *gin.Context) {
 	}
 	fmt.Println("Generated Summary: ", generatedSummary)
 	fmt.Println("Proposed Solutions: ", proposedSolutions)
-	fmt.Printf("Soultion Sources: %+v\n", proposedSolutions.SolutionSources)
+	fmt.Printf("Solution Sources: %+v\n", proposedSolutions.SolutionSources)
+
+	formattedAnalysisLogs := strings.Split(logAnalysisPayload.Logs, "\n")
 
 	c.issuesCollection.InsertOne(ctx, models.Issue{
 		Id:                        issueId,
 		UserId:                    logAnalysisPayload.UserId,
 		ContainerName:             logAnalysisPayload.ContainerName,
-		Severtiy:                  strings.ToUpper("Critical"),                             // TODO: Implement severity detection
+		Severity:                  strings.ToUpper("Critical"),                             // TODO: Implement severity detection
 		Title:                     "Sample issue title from 8 to 15 words. Quick summary.", // TODO: Produce title
 		TimeStamp:                 time.Now(),
 		IsResolved:                false,
-		Logs:                      logAnalysisPayload.Logs,
+		Logs:                      formattedAnalysisLogs,
 		LogSummary:                generatedSummary,
 		PredictedSolutionsSummary: proposedSolutions.SolutionSummary,
 		PredictedSolutionsSources: proposedSolutions.SolutionSources,

--- a/backend/pkg/models/issue.go
+++ b/backend/pkg/models/issue.go
@@ -20,8 +20,8 @@ type Issue struct {
 	Id                        string                                  `json:"id" bson:"_id"`
 	UserId                    string                                  `json:"userId" bson:"userId"`
 	ContainerName             string                                  `json:"containerName" bson:"containerName"`
-	Severtiy                  string                                  `json:"severity" bson:"severity"`
-	Logs                      string                                  `json:"logs" bson:"logs"`
+	Severity                  string                                  `json:"severity" bson:"severity"`
+	Logs                      []string                                `json:"logs" bson:"logs"`
 	Title                     string                                  `json:"title" bson:"title"`
 	IsResolved                bool                                    `json:"isResolved" bson:"isResolved"`
 	TimeStamp                 time.Time                               `json:"timestamp" bson:"timestamp"`


### PR DESCRIPTION
After running the analysis we can now save the logs as an array of strings in the DB instead of plain strings. It will allow us to properly present data on the Frontend side. 